### PR TITLE
Less SVG attributes (compile time optimization)

### DIFF
--- a/src/React/Icons/Types.purs
+++ b/src/React/Icons/Types.purs
@@ -1,13 +1,16 @@
 module React.Icons.Types where
 
 import React.Basic (JSX, ReactComponent)
-import React.Basic.DOM.Internal (SharedSVGProps)
+import React.Basic.DOM (CSS)
 
 type ReactIcon = ReactComponent (Record PropsIcon)
 
-type PropsIcon = SharedSVGProps
+type PropsIcon =
   ( children :: JSX
   , size :: String
   , color :: String
   , title :: String
+  , id :: String
+  , className :: String
+  , style :: CSS
   )


### PR DESCRIPTION
Reducing the amount of svg attributes in order to bring down compile times and size (`externs.cbor`).

## Example

Markdown `externs.cbor` down from 43 MB to 7 MB.